### PR TITLE
Release Version 6

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,11 +1,11 @@
 {
   "arrowParens": "always",
+  "bracketSameLine": true,
   "bracketSpacing": true,
   "embeddedLanguageFormatting": "auto",
   "endOfLine": "lf",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
-  "jsxBracketSameLine": true,
   "jsxSingleQuote": false,
   "printWidth": 80,
   "proseWrap": "preserve",

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -12,6 +12,7 @@
   "quoteProps": "as-needed",
   "requirePragma": false,
   "semi": false,
+  "singleAttributePerLine": false,
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "none",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "author": "Nick Petruzzelli <code.npetruzzelli@gmail.com>",
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "prettier": "^2.6.0"
+    "prettier": "^2.6.0 || ^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-standard",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A Prettier shareable config for projects using 'Prettier' and 'JavaScript Standard Style' as ESLint rules or separate processes.",
   "main": ".prettierrc.json",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "author": "Nick Petruzzelli <code.npetruzzelli@gmail.com>",
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "prettier": "^2.4.0"
+    "prettier": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-standard",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "A Prettier shareable config for projects using 'Prettier' and 'JavaScript Standard Style' as ESLint rules or separate processes.",
   "main": ".prettierrc.json",
   "repository": {
@@ -25,6 +25,6 @@
   "author": "Nick Petruzzelli <code.npetruzzelli@gmail.com>",
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "prettier": ">= 2.0.0 < 2.4.0"
+    "prettier": "^2.4.0"
   }
 }


### PR DESCRIPTION
- [Explicitly set `singleAttributePerLine` option added in Prettier 2.6](https://prettier.io/blog/2022/03/16/2.6.0#enforce-single-attribute-per-line-6644httpsgithubcomprettierprettierpull6644-by-kankjehttpsgithubcomkankje)
- Include Prettier 3.x in peer dependencies (See #8 )